### PR TITLE
Added include of stdint.h for uint8_t on linux and two functions

### DIFF
--- a/include/FFmpegVideoPlayer.h
+++ b/include/FFmpegVideoPlayer.h
@@ -15,6 +15,8 @@
 #include <OgreTextureManager.h>
 #include <deque>
 
+#include <stdint.h>
+
 // Forward declarations
 namespace Ogre
 {
@@ -385,6 +387,16 @@ public:
      * Sets the desired sample format for the decoding thread to use when converting audio
      */
     void setAudioSampleFormat(AudioSampleFormat fmt);
+
+    /**
+     * Obtains the number of video frames currently buffered.
+     */
+    unsigned int getBufferedVideoFrames() const;
+
+    /**
+     * Obtains the number of audio frames currently buffered.
+     */
+    unsigned int getBufferedAudioFrames() const;
     
 private:
     Ogre::String    _materialName;

--- a/src/FFmpegVideoPlayer.cpp
+++ b/src/FFmpegVideoPlayer.cpp
@@ -718,3 +718,13 @@ FFmpegVideoPlayer::frameStarted(const Ogre::FrameEvent& p_evt)
     
     return true;
 }
+
+unsigned int FFmpegVideoPlayer::getBufferedVideoFrames() const
+{
+    return _videoFrames.size();
+}
+
+unsigned int FFmpegVideoPlayer::getBufferedAudioFrames() const
+{
+    return _audioFrames.size();
+}


### PR DESCRIPTION
Just adding some minor stuff now that I've forked your great plugin. I needed to know how many frames are left when the video was ending (I'm using it with getVideoInfo().decodingDone). The include is for uint8_t because it would not be defined on GNU/Linux. If you don't want these functions, just add the include and deny this one :)
